### PR TITLE
PR Template Update

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bug_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug_pr_template.md
@@ -1,13 +1,26 @@
----
-name: Bug Fix
-about: Fix a bug to resolve an issue
-title: "[BUG FIX]"
-labels: bug
-assignees: ''
+## /** DELETE THIS SECTION AFTER READING */
+Please prepend the title of the PR with `[BUG FIX]`.
+## /** DELETE THIS SECTION AFTER READING */
 
----
 
-**Link to bug issue: ** 
+
+**Link to issue: ** If applicable, link an issue
+
+**Changes made**
+* List down the specifics about the change made
+
+**New behavior**
+A clear and concise description of what will happen with the bug fixed.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment Tested On (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.**Link to bug issue: ** 
 
 **Changes made**
 * List down the changes made to fix the bug

--- a/.github/PULL_REQUEST_TEMPLATE/change_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/change_pr_template.md
@@ -1,11 +1,9 @@
----
-name: Change
-about: Merge in a specific change made for a primary goal or feature
-title: "[CHANGE]"
-labels: change
-assignees: ''
+## /** DELETE THIS SECTION AFTER READING */
+* Please prepend the title of the PR with `[NEW]` only if it adds something new.
+* Please prepend the title of the PR with `[UPDATE]` for other cases.
+## /** DELETE THIS SECTION AFTER READING */
 
----
+
 
 **Link to issue: ** If applicable, link an issue
 

--- a/.github/PULL_REQUEST_TEMPLATE/fr_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/fr_pr_template.md
@@ -1,11 +1,8 @@
----
-name: New Feature
-about: Add a new feature to satisfy a feature request issue
-title: "[NEW FEATURE]"
-labels: enhancement
-assignees: ''
+## /** DELETE THIS SECTION AFTER READING */
+Please prepend the title of the PR with `[NEW FEATURE]`.
+## /** DELETE THIS SECTION AFTER READING */
 
----
+
 
 **Link to feeature request issue: ** 
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## /** DELETE THIS SECTION AFTER READING */
+* If you're creating a bug fix PR, append `?quick_pull=1&template=bug_pr_template.md` to the end of the current PR url.
+* If you're creating a feature request PR, append `?quick_pull=1&template=fr_pr_template.md` to the end of the current PR url.
+* If you're creating a specifc change PR, append `?quick_pull=1&template=change_pr_template.md` to the end of the current PR url.
+* If you're creating any other CR type, delete this section and continue filling the details.
+## /** DELETE THIS SECTION AFTER READING */
+
+
+
+**Link to issue: ** If applicable, link an issue
+
+**Changes made**
+* List down the specifics about the change made
+
+**New behavior**
+A clear and concise description of what will happen with the bug fixed.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment Tested On (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
**Link to issue: ** NA

**Changes made**
* Update the three templates for specific PR scenarios.
* Add a default PR template that *hopefully* gets picked up by GitHub as a default.

**New behavior**
When creating a PR, GitHub should load the default template, which will provide instructions for switching to the other more specific templates if required.

GitHub does not currently provide a UI for selecting a PR template, hence the requirement of this patch.

**Screenshots**
NA

**Environment Tested On (please complete the following information):**
 - OS: NA
 - Version: NA

**Additional context**
This template was picked through the required process which was found online.
Also this change cannot be verified without merging.